### PR TITLE
tighter version bound on Click

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setuptools.setup(
     author_email="shawnpresser@gmail.com",
     url="https://github.com/shawwn/tpunicorn",
     install_requires=[
-        'Click>=7.1.2',
+        'Click>=7.1.2,<8.0',
         'six>=1.11.0',
         'ring>=0.7.3',
         'moment>=0.0.10',


### PR DESCRIPTION
without the tighter bound it tries to install Click 8.0, which leads to the following error on line 156 of `program.py`:
`TypeError: Parameter.__init__() got an unexpected keyword argument 'autocompletion'`
verified working on my laptop at least